### PR TITLE
掲示板一覧ページを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -39,6 +39,7 @@ body, div, ul, ol, li, h1, h2, h3, p {
 body {
   position: relative;
   box-sizing: border-box;
+  background-color: #f5f5f5;
   min-height: 100vh;
   padding-bottom: 38px;
 }
@@ -56,7 +57,6 @@ body {
 }
 
 .main {
-  background-color: #f5f5f5;
   padding: 40px 0;
 }
 

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -7,6 +7,7 @@
 2. new.html.erb
 3. edit.html.erb
 4. _form.html.erb
+5. list.html.erb
 =========================== */
 
 /* ===========================
@@ -194,4 +195,57 @@
   width: 434px;
   padding: 10px;
   margin-top: 10px;
+}
+
+/* ===========================
+  5. list.html.erb
+=========================== */
+.game-list-section {
+  background-color: white;
+  width: 100%;
+  padding: 40px;
+}
+
+.game-list-section h1, .game-list-section h3 {
+  margin-bottom: 20px;
+}
+
+.game-count {
+  font-size: 24px;
+}
+
+.game-list-section table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.game-list-section th, .game-list-section td {
+  width: 20%;
+  padding: 10px;
+}
+
+.game-list-section th {
+  border-bottom: 1px solid black;
+}
+
+.game-list-section th:nth-of-type(2), .game-list-section td:nth-of-type(2) {
+  text-align: center;
+}
+
+.game-list-section th:nth-of-type(3), .game-list-section td:nth-of-type(3) {
+  width: 50%;
+}
+
+.game-list-section th:last-of-type, .game-list-section td:last-of-type {
+  text-align: center;
+  width: 10%;
+}
+
+.edit-game-link {
+  text-decoration: none;
+  color: blue;
+}
+
+.edit-game-link:hover {
+  text-decoration: underline;
 }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -34,6 +34,10 @@ class GamesController < ApplicationController
     end
   end
 
+  def list
+    @games = Game.where(user_id: current_user.id)
+  end
+
   private
 
   def game_params

--- a/app/views/games/list.html.erb
+++ b/app/views/games/list.html.erb
@@ -1,0 +1,20 @@
+<div class="game-list-section">
+  <h1>作成した掲示板一覧</h1>
+  <h3>合計<span class="game-count"><%= @games.count %></span>件</h3>
+  <table>
+    <tr>
+      <th>ゲーム名</th>
+      <th>ページの用途</th>
+      <th>ページの説明</th>
+      <th>編集</th>
+    </tr>
+    <% @games.each do |game| %>
+      <tr>
+        <td><%= game.name %></td>
+        <td><%= game.purpose %></td>
+        <td><%= game.description %></td>
+        <td><%= link_to "編集", edit_game_path(game), class: "edit-game-link" %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/shared/_logged_in.html.erb
+++ b/app/views/shared/_logged_in.html.erb
@@ -8,5 +8,6 @@
 </div>
 <div class="header-box">
   <%= link_to "ユーザー情報の編集", edit_user_registration_path, class: "header-box-link" %>
+  <%= link_to "作成した掲示板一覧", games_list_path, class: "header-box-link" %>
   <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "header-box-link" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root 'games#index'
+
+  get 'games/list'
   resources :games
 
   devise_for :users

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -9,4 +9,22 @@ FactoryBot.define do
       name { nil }
     end
   end
+
+  factory :game_after_change, class: "Game" do
+    association :user
+    name { "変更後テストゲーム" }
+    purpose { "テスト" }
+    description { "テスト用説明文です。" }
+
+    trait :invalid do
+      name { nil }
+    end
+  end
+
+  factory :another_game, class: "Game" do
+    association :user
+    name { "別のテストゲーム" }
+    purpose { "別のテスト" }
+    description { "別のテスト用説明文です。" }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,12 +3,13 @@ FactoryBot.define do
     name { "テストユーザー" }
     sequence(:email) { |n| "test#{n}@example.com" }
     password { "testuser" }
-  end
 
-  factory :user_with_icon, class: "User" do
-    name { "テストユーザー" }
-    icon { Rack::Test::UploadedFile.new("#{Rails.root}/spec/factories/test.jpg", "image/jpeg") }
-    sequence(:email) { |n| "icon-test#{n}@example.com" }
-    password { "testuser" }
+    trait :with_icon do
+      icon { Rack::Test::UploadedFile.new("#{Rails.root}/spec/factories/test.jpg", "image/jpeg") }
+    end
+
+    trait :guest do
+      email { "guest@example.com" }
+    end
   end
 end

--- a/spec/support/edit_user_module.rb
+++ b/spec/support/edit_user_module.rb
@@ -1,22 +1,13 @@
 module EditUserModule
-  def configure_icon(user)
+  def edit(user, icon_setting)
     visit edit_user_registration_path
     within ".user-edit-form" do
       fill_in "名前", with: user.name
-      attach_file "アイコン画像", "#{Rails.root}/spec/factories/test.jpg"
-      fill_in "メールアドレス", with: user.email
-      fill_in "新しいパスワード", with: ""
-      fill_in "新しいパスワード（確認用）", with: ""
-      fill_in "現在のパスワード", with: user.password
-      click_on "更新"
-    end
-  end
-
-  def unconfigure_icon(user)
-    visit edit_user_registration_path
-    within ".user-edit-form" do
-      fill_in "名前", with: user.name
-      check "アイコン画像をデフォルトに戻す"
+      if icon_setting == "add_icon"
+        attach_file "アイコン画像", "#{Rails.root}/spec/factories/test.jpg"
+      else
+        check "アイコン画像をデフォルトに戻す"
+      end
       fill_in "メールアドレス", with: user.email
       fill_in "新しいパスワード", with: ""
       fill_in "新しいパスワード（確認用）", with: ""

--- a/spec/system/games_spec.rb
+++ b/spec/system/games_spec.rb
@@ -2,10 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Games", type: :system, js: true do
   let(:user) { create(:user) }
-  let(:guest_user) { create(:user, email: "guest@example.com") }
   let!(:game) { create(:game, user: user) }
-  let(:another_game) { create(:game) }
-  let(:invalid_game) { build(:game, :invalid, user: user) }
 
   describe "トップページ" do
     before do
@@ -56,7 +53,7 @@ RSpec.describe "Games", type: :system, js: true do
 
         context "アイコン画像登録済みの場合" do
           before do
-            configure_icon(user)
+            edit(user, "add_icon")
           end
 
           it "ヘッダー内にユーザーの名前とアイコン画像が表示されること" do
@@ -154,6 +151,8 @@ RSpec.describe "Games", type: :system, js: true do
       end
 
       context "ゲストユーザーでログインしている場合" do
+        let(:guest_user) { create(:user, :guest) }
+
         before do
           sign_in_as(guest_user)
         end
@@ -169,6 +168,8 @@ RSpec.describe "Games", type: :system, js: true do
   end
 
   describe "掲示板作成ページ" do
+    let(:invalid_game) { build(:game, :invalid, user: user) }
+
     before do
       sign_in_as(user)
       visit new_game_path
@@ -205,6 +206,9 @@ RSpec.describe "Games", type: :system, js: true do
   end
 
   describe "掲示板情報編集ページ" do
+    let(:invalid_game) { build(:game, :invalid, user: user) }
+    let(:another_game) { create(:another_game) }
+
     before do
       sign_in_as(user)
       visit edit_game_path(game.id)

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Users", type: :system, js: true do
       context "アイコン画像登録済みの場合" do
         before do
           sign_in_as(user)
-          configure_icon(user)
+          edit(user, "add_icon")
           visit edit_user_registration_path
         end
 
@@ -105,7 +105,7 @@ RSpec.describe "Users", type: :system, js: true do
         end
 
         it "変更したい項目と現在のパスワードを入力して「更新」をクリックすると、ユーザー情報が更新されてトップページに遷移すること" do
-          configure_icon(user)
+          edit(user, "add_icon")
           expect(current_path).to eq root_path
           expect(page).to have_content "Your account has been updated successfully."
         end
@@ -134,12 +134,12 @@ RSpec.describe "Users", type: :system, js: true do
       context "アイコン画像登録済みの場合" do
         before do
           sign_in_as(user)
-          configure_icon(user)
+          edit(user, "add_icon")
           visit edit_user_registration_path
         end
 
         it "「アイコン画像をデフォルトに戻す」にチェックを入れてユーザー情報を更新すると、アイコン画像が削除されること" do
-          unconfigure_icon(user)
+          edit(user, "remove_icon")
           expect(current_path).to eq root_path
           expect(page).to have_content "Your account has been updated successfully."
           expect(user.icon.url).to eq nil


### PR DESCRIPTION
掲示板一覧ページを作成しました。

●掲示板一覧ページ
あるユーザーの掲示板一覧ページには、そのユーザーが作成した掲示板の情報が表示されます。
「編集」をクリックすると、その掲示板の情報編集ページに遷移することができます。