### PR TITLE
チャットページを作成

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -4,10 +4,10 @@
 
 /* ========== index ==========
 1. index.html.erb
-2. new.html.erb
-3. edit.html.erb
-4. _form.html.erb
-5. list.html.erb
+2. new.html.erb, edit.html.erb
+3. show.html.erb
+4. list.html.erb
+5. _form.html.erb
 =========================== */
 
 /* ===========================
@@ -122,7 +122,7 @@
 }
 
 /* ===========================
-  2. new.html.erb
+  2. new.html.erb, edit.html.erb
 =========================== */
 .game-section {
   background-color: white;
@@ -148,57 +148,87 @@
 }
 
 /* ===========================
-  3. edit.html.erb
+  3. show.html.erb
 =========================== */
-/* ===========================
-  4. _form.html.erb
-=========================== */
-.game-form {
-  text-align: left;
+.chat-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: white;
+  width: 100%;
+  padding: 40px;
 }
 
-.game-form table {
-  border-collapse: collapse;
+.chat-section h1, .chat-section > p {
+  margin-bottom: 20px;
 }
 
-.game-form th, .game-form td {
+.chat-section h1 span {
+  margin-right: 1em;
+}
+
+.chat-form {
+  display: inline-block;
+  border: 2px solid #00bfff;
   padding: 10px;
+  margin-bottom: 20px;
 }
 
-.game-label {
-}
-
-.game-field {
+.chat-text-area {
   font-size: 16px;
-  width: 300px;
-  height: 30px;
+  width: 434px;
+  height: 115px;
 }
 
-.game-select-field {
-  font-size: 16px;
-  width: 308px;
-  height: 36px;
-}
-
-.game-text-area {
-  font-size: 16px;
-  width: 302px;
-  height: 90px;
-}
-
-.game-button {
+.chat-submit {
   cursor: pointer;
+  display: block;
   border: none;
   background-color: blue;
   color: white;
   font-size: 16px;
-  width: 434px;
+  width: 440px;
   padding: 10px;
   margin-top: 10px;
 }
 
+.chat-list {
+  list-style-type: none;
+  border: 2px solid blue;
+  width: 440px;
+  padding: 0 10px;
+}
+
+.chat-list-item {
+  border-bottom: 1px solid black;
+  padding: 10px;
+}
+
+.chat-list-item:last-of-type {
+  border: none;
+}
+
+.chat-header {
+  display: block;
+  text-align: center;
+  font-weight: bold;
+}
+
+.chat-list-item h3 span {
+  margin-right: 1em;
+}
+
+.chat-list-item p {
+  margin: 10px 0;
+}
+
+.chat-creation-date {
+  color: #808080;
+  font-size: 12px;
+}
+
 /* ===========================
-  5. list.html.erb
+  4. list.html.erb
 =========================== */
 .game-list-section {
   background-color: white;
@@ -248,4 +278,48 @@
 
 .edit-game-link:hover {
   text-decoration: underline;
+}
+
+/* ===========================
+  5. _form.html.erb
+=========================== */
+.game-form {
+  text-align: left;
+}
+
+.game-form table {
+  border-collapse: collapse;
+}
+
+.game-form th, .game-form td {
+  padding: 10px;
+}
+
+.game-field {
+  font-size: 16px;
+  width: 300px;
+  height: 30px;
+}
+
+.game-select-field {
+  font-size: 16px;
+  width: 308px;
+  height: 36px;
+}
+
+.game-text-area {
+  font-size: 16px;
+  width: 302px;
+  height: 90px;
+}
+
+.game-button {
+  cursor: pointer;
+  border: none;
+  background-color: blue;
+  color: white;
+  font-size: 16px;
+  width: 434px;
+  padding: 10px;
+  margin-top: 10px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,10 +14,4 @@ class ApplicationController < ActionController::Base
       redirect_to root_path, alert: "ゲストユーザーの情報は変更できません"
     end
   end
-
-  def exclude_not_logged_in_user
-    unless user_signed_in?
-      redirect_to new_user_session_path, alert: "ログインしてください"
-    end
-  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -20,6 +20,12 @@ class GamesController < ApplicationController
     end
   end
 
+  def show
+    @game = Game.find(params[:id])
+    @posts = Post.where(game_id: @game.id)
+    @post = Post.new
+  end
+
   def edit
     @game = Game.find(params[:id])
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,5 @@
 class GamesController < ApplicationController
-  before_action :exclude_not_logged_in_user, except: :index
+  before_action :authenticate_user!, except: :index
   before_action :ensure_correct_user, only: [:edit, :update]
 
   def index

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -22,7 +22,7 @@ class GamesController < ApplicationController
 
   def show
     @game = Game.find(params[:id])
-    @posts = Post.where(game_id: @game.id)
+    @posts = Post.where(game_id: @game.id).includes(:user)
     @post = Post.new
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,19 @@
+class PostsController < ApplicationController
+  def create
+    @game = Game.find(params[:game_id])
+    @posts = Post.where(game_id: @game.id)
+    @post = Post.new(post_params)
+
+    if @post.save
+      redirect_to game_path(@game)
+    else
+      render "games/show"
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:text).merge(user_id: current_user.id, game_id: @game.id)
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,5 +1,6 @@
 class Game < ApplicationRecord
   belongs_to :user
+  has_many :posts
 
   with_options presence: true do
     validates :name

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,10 @@
 class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :game
+
+  with_options presence: true do
+    validates :text
+    validates :user_id
+    validates :game_id
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :games
+  has_many :posts
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,9 +1,9 @@
 <div class="game-list">
-  <p>ゲーム一覧</p>
+  <p>掲示板一覧</p>
   <ul>
     <% @games.each do |game| %>
       <li>
-        <%= link_to game.name, root_path, class: "game-link" %>
+        <%= link_to "#{game.name}#{game.purpose}掲示板", game_path(game), class: "game-link" %>
       </li>
     <% end %>
   </ul>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,22 @@
+<div class="chat-section">
+  <h1><span><%= @game.name %></span><%= @game.purpose %>掲示板</h1>
+  <p><%= @game.description %></p>
+  <%= form_with model: [@game, @post], class: "chat-form" do |f| %>
+    <h3>投稿する</h3>
+    <%= render "shared/error_messages", resource: @post %>
+    <%= f.text_area :text, class: "chat-text-area" %>
+    <%= f.submit "投稿する", class: "chat-submit" %>
+  <% end %>
+  <ol class="chat-list">
+    <li class="chat-list-item">
+      <span class="chat-header">チャット</span>
+    </li>
+    <% @posts.each.with_index(1).reverse_each do |post, index| %>
+      <li class="chat-list-item">
+        <h3><span><%= index %></span><%= post.user.name %></h3>
+        <p><%= post.text %></p>
+        <span class="chat-creation-date"><%= post.created_at %></span>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   root 'games#index'
 
   get 'games/list'
-  resources :games
+  resources :games do
+    resources :posts, only: :create
+  end
 
   devise_for :users
   devise_scope :user do

--- a/db/migrate/20220128125330_create_posts.rb
+++ b/db/migrate/20220128125330_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :posts do |t|
+      t.text :text
+      t.integer :user_id
+      t.integer :game_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_22_115829) do
+ActiveRecord::Schema.define(version: 2022_01_28_125330) do
 
   create_table "games", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 2022_01_22_115829) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
+  end
+
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "text"
+    t.integer "user_id"
+    t.integer "game_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :post do
+    association :user
+    association :game
+    text { "テスト用チャットです。" }
+
+    trait :invalid do
+      text { nil }
+    end
+  end
+
+  factory :another_post, class: "Post" do
+    association :user
+    association :game
+    text { "別のテスト用チャットです。" }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  describe "バリデーション" do
+    it "チャット本文、user_id、game_idがあれば有効であること" do
+      user = create(:user)
+      game = create(:game)
+      post = build(:post, user_id: user.id, game_id: game.id)
+      expect(post).to be_valid
+    end
+
+    it "チャット本文がなければ無効であること" do
+      post = build(:post, text: nil)
+      post.valid?
+      expect(post.errors[:text]).to include "can't be blank"
+    end
+
+    it "user_idがなければ無効であること" do
+      post = build(:post, user_id: nil)
+      post.valid?
+      expect(post.errors[:user_id]).to include "can't be blank"
+    end
+
+    it "game_idがなければ無効であること" do
+      post = build(:post, game_id: nil)
+      post.valid?
+      expect(post.errors[:game_id]).to include "can't be blank"
+    end
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Games", type: :request do
       expect(response).to have_http_status(200)
     end
 
-    it "レスポンスにゲーム名が含まれること" do
-      expect(response.body).to include game.name
+    it "チャットページの名前が表示されること" do
+      expect(response.body).to include "#{game.name}#{game.purpose}掲示板"
     end
 
     context "ログインしていない場合" do
@@ -110,10 +110,41 @@ RSpec.describe "Games", type: :request do
     end
   end
 
+  describe "GET #show" do
+    let!(:post) { create(:post, game: game) }
+
+    before do
+      sign_in user
+      get game_path(game)
+    end
+
+    it "リクエストが成功すること" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "掲示板の情報が表示されること" do
+      expect(response.body).to include game.name
+      expect(response.body).to include game.purpose
+      expect(response.body).to include game.description
+    end
+
+    it "チャットを投稿したユーザーの名前が表示されること" do
+      expect(response.body).to include post.user.name
+    end
+
+    it "チャットの内容が表示されること" do
+      expect(response.body).to include post.text
+    end
+
+    it "チャットの作成日時が表示されること" do
+      expect(response.body).to include post.created_at.to_s
+    end
+  end
+
   describe "GET #edit" do
     before do
       sign_in user
-      get edit_game_path(game.id)
+      get edit_game_path(game)
     end
 
     it "リクエストが成功すること" do
@@ -145,36 +176,36 @@ RSpec.describe "Games", type: :request do
 
     context "パラメータが有効である場合" do
       it "リクエストが成功すること" do
-        patch game_path(game.id), params: { game: game_params }
+        patch game_path(game), params: { game: game_params }
         expect(response).to have_http_status(302)
       end
 
       it "データが更新されること" do
         expect do
-          patch game_path(game.id), params: { game: game_params_after_change }
+          patch game_path(game), params: { game: game_params_after_change }
         end.to change { Game.find(game.id).name }.from("テストゲーム").to("変更後テストゲーム")
       end
 
       it "リダイレクトされること" do
-        patch game_path(game.id), params: { game: game_params }
+        patch game_path(game), params: { game: game_params }
         expect(response).to redirect_to root_path
       end
     end
 
     context "パラメータが無効である場合" do
       it "リクエストが成功すること" do
-        patch game_path(game.id), params: { game: invalid_game_params }
+        patch game_path(game), params: { game: invalid_game_params }
         expect(response).to have_http_status(200)
       end
 
       it "データが更新されないこと" do
         expect do
-          patch game_path(game.id), params: { game: invalid_game_params_after_change }
+          patch game_path(game), params: { game: invalid_game_params_after_change }
         end.not_to change { Game.find(game.id).name }
       end
 
       it "エラーが表示されること" do
-        patch game_path(game.id), params: { game: invalid_game_params }
+        patch game_path(game), params: { game: invalid_game_params }
         expect(response.body).to include "更新できませんでした"
       end
     end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  let(:user) { create(:user) }
+  let(:game) { create(:game) }
+  let(:new_post) { create(:post, game: game, user: user) }
+
+  describe "POST #create" do
+    let(:post_params) { attributes_for(:post) }
+    let(:invalid_post_params) { attributes_for(:post, :invalid) }
+
+    before do
+      sign_in user
+    end
+
+    context "パラメータが有効である場合" do
+      it "リクエストが成功すること" do
+        post game_posts_path(game), params: { post: post_params }
+        expect(response).to have_http_status(302)
+      end
+
+      it "データベースへの保存が成功すること" do
+        expect do
+          post game_posts_path(game), params: { post: post_params }
+        end.to change { Post.count }.by(1)
+      end
+
+      it "リダイレクトされること" do
+        post game_posts_path(game), params: { post: post_params }
+        expect(response).to redirect_to game_path(game)
+      end
+    end
+
+    context "パラメータが無効である場合" do
+      it "リクエストが成功すること" do
+        post game_posts_path(game), params: { post: invalid_post_params }
+        expect(response).to have_http_status(200)
+      end
+
+      it "データベースに保存されないこと" do
+        expect do
+          post game_posts_path(game), params: { post: invalid_post_params }
+        end.not_to change { Post.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
チャットページを作成しました。

●機能の説明
テキストを入力して「投稿する」をクリックすると保存され、チャットページ内の「チャット」の部分に、投稿の順番・投稿したユーザー名・投稿の内容・作成日時が表示されます。投稿はより新しいものが上に表示されます。