### PR TITLE
掲示板検索機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'carrierwave'
 gem 'fog-aws'
+gem 'ransack'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (2.5.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -337,6 +341,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.4)
+  ransack
   rspec-rails
   rspec_junit_formatter
   rubocop-airbnb

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -7,7 +7,8 @@
 2. new.html.erb, edit.html.erb
 3. show.html.erb
 4. list.html.erb
-5. _form.html.erb
+5. search.html.erb
+6. _form.html.erb
 =========================== */
 
 /* ===========================
@@ -28,18 +29,47 @@
   }
 }
 
-.game-list p {
+.game-name-search, .game-list-item {
+  border-bottom: 2px solid black;
+  margin-bottom: 20px;
+}
+
+.game-name-search p, .game-list-item p {
   text-align: center;
   font-size: 20px;
   font-weight: bold;
   margin-bottom: 20px;
 }
 
-.game-list ul {
+.search-form {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.search-field {
+  font-size: 16px;
+  width: 76%;
+  height: 38px;
+}
+
+.search-submit {
+  cursor: pointer;
+  border: none;
+  border-radius: 5px;
+  background-color: blue;
+  color: white;
+  font-size: 16px;
+  width: 20%;
+  //height: 30px;
+  padding: 7px 0;
+}
+
+.game-list-item ul {
   padding-left: 20px;
 }
 
-.game-list li {
+.game-list-item ul li {
   margin-bottom: 20px;
 }
 
@@ -340,7 +370,70 @@
 }
 
 /* ===========================
-  5. _form.html.erb
+  5. search.html.erb
+=========================== */
+.game-search-section {
+  background-color: white;
+  width: 100%;
+  padding: 40px;
+}
+
+@media screen and (max-width: 767px) {
+  .game-search-section {
+    width: calc(100% - 80px);
+  }
+}
+
+.game-search-section h2 {
+  margin-bottom: 20px;
+}
+
+.game-search-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  list-style-type: none;
+}
+
+@media screen and (max-width: 767px) {
+  .game-search-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+.game-search-link {
+  text-decoration: none;
+  color: black;
+  border: 2px solid blue;
+  margin: 0 10px 20px;
+}
+
+@media screen and (max-width: 767px) {
+  .game-search-link {
+    width: 100%;
+  }
+}
+
+.game-search-item {
+  padding: 10px;
+}
+
+.game-search-item p:first-of-type {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.game-search-item p span {
+  margin-right: 1em;
+}
+
+.game-search-item p:last-of-type {
+  color: #808080;
+  font-size: 14px;
+}
+
+/* ===========================
+  6. _form.html.erb
 =========================== */
 .game-form {
   text-align: left;

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,9 +1,13 @@
 class GamesController < ApplicationController
+  MAX_GAMES_COUNT = 5
+
   before_action :authenticate_user!, except: :index
   before_action :ensure_correct_user, only: [:edit, :update]
 
   def index
-    @games = Game.all
+    @games = Game.joins(:posts).select(:name).group(:name).order("count(text) desc").
+      limit(MAX_GAMES_COUNT)
+    @q = Game.ransack(params[:q])
   end
 
   def new
@@ -42,6 +46,11 @@ class GamesController < ApplicationController
 
   def list
     @games = Game.where(user_id: current_user.id)
+  end
+
+  def search
+    @q = Game.ransack(params[:q])
+    @games = @q.result(distinct: true)
   end
 
   private

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,12 +1,21 @@
 <div class="game-list">
-  <p>掲示板一覧</p>
-  <ul>
-    <% @games.each do |game| %>
-      <li>
-        <%= link_to "#{game.name}#{game.purpose}掲示板", game_path(game), class: "game-link" %>
-      </li>
+  <div class="game-name-search">
+    <p>ゲーム検索</p>
+    <%= search_form_for @q, url: search_games_path, class: "search-form" do |f| %>
+      <%= f.search_field :name_cont, placeholder: "ゲーム名で検索", class: "search-field" %>
+      <%= f.submit "検索", class: "search-submit" %>
     <% end %>
-  </ul>
+  </div>
+  <div class="game-list-item">
+    <p>人気のゲーム</p>
+    <ul>
+      <% @games.each do |game| %>
+        <li>
+          <%= link_to game.name, search_games_path(@q, "q[name_cont]": game.name), class: "game-link" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
   <%= link_to "新しい掲示板を作成", new_game_path, class: "new-game-link" %>
 </div>
 <div class="top-main">
@@ -24,11 +33,11 @@
     <ol>
       <li>
         <p>&#9312ゲームを選択</p>
-        <p>このページの左側の「ゲーム一覧」からゲームを選択します。</p>
+        <p>このページの左側の「ゲーム」からゲームを検索します。</p>
       </li>
       <li>
-        <p>&#9313何をするか選択</p>
-        <p>交換、対戦、仲間募集の中から選択します。</p>
+        <p>&#9313掲示板を選択</p>
+        <p>目的に合った掲示板を選択します。</p>
       </li>
       <li>
         <p>&#9314チャットでやりとり</p>

--- a/app/views/games/search.html.erb
+++ b/app/views/games/search.html.erb
@@ -1,0 +1,14 @@
+<div class="game-search-section">
+  <h2 class="game-search-word">検索ワード：<%= params[:q][:name_cont] if params[:q] %></h2>
+  <h2 class="game-search-count">検索結果（<%= @games.count %>件）</h2>
+  <ul class="game-search-list">
+    <% @games.each do |game| %>
+      <%= link_to game_path(game), class: "game-search-link" do %>
+        <li class="game-search-item">
+          <p><span><%= game.name %></span><%= game.purpose %>掲示板</p>
+          <p><%= game.description %></p>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/shared/_logged_in.html.erb
+++ b/app/views/shared/_logged_in.html.erb
@@ -8,6 +8,6 @@
 </div>
 <div class="header-box">
   <%= link_to "ユーザー情報の編集", edit_user_registration_path, class: "header-box-link" %>
-  <%= link_to "作成した掲示板一覧", games_list_path, class: "header-box-link" %>
+  <%= link_to "作成した掲示板一覧", list_games_path, class: "header-box-link" %>
   <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "header-box-link" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
   root 'games#index'
 
-  get 'games/list'
   resources :games do
+    collection do
+      get 'list'
+      get 'search'
+    end
     resources :posts, only: :create
   end
 

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,9 +1,16 @@
 FactoryBot.define do
   factory :game do
-    association :user
     name { "テストゲーム" }
     purpose { "テスト" }
     description { "テスト用説明文です。" }
+    association :user
+
+    trait :with_post do
+      sequence(:name) { |n| "チャット付きゲーム#{n}" }
+      after(:create) do |game|
+        create(:post, game: game)
+      end
+    end
 
     trait :invalid do
       name { nil }
@@ -11,10 +18,10 @@ FactoryBot.define do
   end
 
   factory :game_after_change, class: "Game" do
-    association :user
-    name { "変更後テストゲーム" }
+    name { "変更後ゲーム" }
     purpose { "テスト" }
     description { "テスト用説明文です。" }
+    association :user
 
     trait :invalid do
       name { nil }
@@ -22,9 +29,9 @@ FactoryBot.define do
   end
 
   factory :another_game, class: "Game" do
-    association :user
-    name { "別のテストゲーム" }
+    name { "別のゲーム" }
     purpose { "別のテスト" }
     description { "別のテスト用説明文です。" }
+    association :user
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :post do
-    association :user
-    association :game
     text { "テスト用チャットです。" }
+    association :game
+    association :user
 
     trait :invalid do
       text { nil }
@@ -10,8 +10,8 @@ FactoryBot.define do
   end
 
   factory :another_post, class: "Post" do
-    association :user
+    text { "別のチャットです。" }
     association :game
-    text { "別のテスト用チャットです。" }
+    association :user
   end
 end


### PR DESCRIPTION
掲示板検索機能を実装しました。
→トップページに検索フォームを追加し、掲示板検索結果ページを作成しました。

●トップページ
トップページの検索フォームに検索ワードを入力して「検索」をクリックすると、検索ワードがゲーム名に含まれている掲示板の一覧が表示されます。何も入力せずに「検索」をクリックすると、全ての掲示板が表示されます。
また、「人気のゲーム」欄には、掲示板に投稿されたチャットの数が多いものから順に、重複なく5個までゲーム名が表示されるようになっています。このゲーム名をクリックすると、このゲーム名を検索ワードとして検索した結果が表示されます。

●掲示板検索結果ページ
検索ワードと検索結果の件数が表示されます。
表示されている掲示板情報をクリックすると、チャットページに遷移します。