### PR TITLE
チャット返信機能を実装

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -281,13 +281,14 @@
   }
 }
 
-.chat-list-item {
+.chat-list li {
+  position: relative;
   overflow-wrap: break-word;
-  border-bottom: 1px solid black;
+  border-top: 1px solid black;
   padding: 10px;
 }
 
-.chat-list-item:last-of-type {
+#chat-list-item-header {
   border: none;
 }
 
@@ -297,17 +298,44 @@
   font-weight: bold;
 }
 
-.chat-list-item h3 span {
+.chat-list li h3 span {
   margin-right: 1em;
 }
 
-.chat-list-item p {
+.chat-list li p {
   margin: 10px 0;
+}
+
+// games_helper.rb内に存在
+.chat-reply-link {
+  text-decoration: none;
+  color: blue;
+}
+
+// games_helper.rb内に存在
+.chat-reply-link:hover {
+  color: #ff4500;
 }
 
 .chat-creation-date {
   color: #808080;
   font-size: 12px;
+}
+
+.chat-reply-button {
+  cursor: pointer;
+  transition-duration: 0.2s;
+  position: absolute;
+  right: 10px;
+  border-radius: 5px;
+  border: 1px solid black;
+  font-size: 16px;
+  padding: 0 20px;
+}
+
+.chat-reply-button:hover {
+  transition-duration: 0.2s;
+  color: #ff4500;
 }
 
 /* ===========================

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,6 @@
 class PostsController < ApplicationController
   def create
     @game = Game.find(params[:game_id])
-    @posts = Post.where(game_id: @game.id)
     @post = Post.new(post_params)
 
     if @post.save

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,0 +1,11 @@
+module GamesHelper
+  def generate_link(text, game)
+    reply_to = text.slice(/>>[0-9]+/)
+    if reply_to
+      reply_to_num = reply_to.slice(/[0-9]+/)
+      link = link_to reply_to, game_path(game, anchor: "chat-list-item-#{reply_to_num}"), class: "chat-reply-link"
+    end
+    content = text.sub(/>>[0-9]+/, "")
+    [link: link, content: content]
+  end
+end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -3,7 +3,9 @@ module GamesHelper
     reply_to = text.slice(/>>[0-9]+/)
     if reply_to
       reply_to_num = reply_to.slice(/[0-9]+/)
-      link = link_to reply_to, game_path(game, anchor: "chat-list-item-#{reply_to_num}"), class: "chat-reply-link"
+      link = link_to reply_to,
+        game_path(game, anchor: "chat-list-item-#{reply_to_num}"),
+        class: "chat-reply-link"
     end
     content = text.sub(/>>[0-9]+/, "")
     [link: link, content: content]

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "jquery"
 import "./common"
+import "./reply_to_chat"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/reply_to_chat.js
+++ b/app/javascript/packs/reply_to_chat.js
@@ -1,0 +1,7 @@
+$(document).on("turbolinks:load", function(){
+  $(".chat-reply-button").click(function(){
+    $(".chat-text-area").focus();
+    let index = $(this).parent().find("h3 span").text();
+    $(".chat-text-area").val(">>" + index + "\n");
+  });
+});

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -17,7 +17,7 @@
           <span><%= generate_link(post.text, @game)[0][:link] %></span>
           <%= safe_join(generate_link(post.text, @game)[0][:content].split("\n"), tag.br) %>
         </p>
-        <span class="chat-creation-date"><%= post.created_at %></span>
+        <span class="chat-creation-date"><%= post.created_at.to_s(:datetime) %></span>
         <span class="chat-reply-button">返信</span>
       </li>
     <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -7,18 +7,18 @@
     <%= f.submit "投稿する", class: "chat-submit" %>
   <% end %>
   <ol class="chat-list">
-    <li class="chat-list-item">
+    <li id="chat-list-item-header">
       <span class="chat-header">チャット</span>
     </li>
     <% @posts.each.with_index(1).reverse_each do |post, index| %>
-      <li class="chat-list-item">
-        <% if post.user %>
-          <h3><span><%= index %></span><%= post.user.name %></h3>
-        <% else %>
-          <h3><span><%= index %></span>アカウント削除済みユーザー</h3>
-        <% end %>
-        <p><%= post.text %></p>
+      <li id="chat-list-item-<%= index %>">
+        <h3><span><%= index %></span><%= post.user ? post.user.name : "アカウント削除済みユーザー" %></h3>
+        <p>
+          <span><%= generate_link(post.text, @game)[0][:link] %></span>
+          <%= safe_join(generate_link(post.text, @game)[0][:content].split("\n"), tag.br) %>
+        </p>
         <span class="chat-creation-date"><%= post.created_at %></span>
+        <span class="chat-reply-button">返信</span>
       </li>
     <% end %>
   </ol>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,9 @@ module Trade
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
+
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.generators do |g|

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime] = "%Y/%m/%d %H:%M"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - db
       - selenium_chrome
     environment:
+      TZ: Asia/Tokyo
       SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
     tty: true
     stdin_open: true

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -7,11 +7,13 @@ FactoryBot.define do
     trait :invalid do
       text { nil }
     end
-  end
 
-  factory :another_post, class: "Post" do
-    text { "別のチャットです。" }
-    association :game
-    association :user
+    trait :another do
+      text { "別のチャットです。" }
+    end
+
+    trait :with_reply_to do
+      text { ">>1テスト用返信チャットです。" }
+    end
   end
 end

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe GamesHelper, type: :helper do
+  describe "generate_link(text, game)" do
+    subject { generate_link(text, game) }
+
+    let(:game) { create(:game) }
+
+    context "textに「>> + 数字」が含まれる場合" do
+      let(:text) { ">>1テスト" }
+
+      it {
+        is_expected.to eq [
+          link: (
+            link_to ">>1", game_path(game, anchor: "chat-list-item-1"), class: "chat-reply-link"
+          ),
+          content: "テスト",
+        ]
+      }
+    end
+
+    context "textに「>> + 数字」が含まれない場合" do
+      let(:text) { "テスト" }
+
+      it { is_expected.to eq [link: nil, content: "テスト"] }
+    end
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Games", type: :request do
     end
 
     it "チャットの作成日時が表示されること" do
-      expect(response.body).to include post.created_at.to_s
+      expect(response.body).to include post.created_at.to_s(:datetime)
     end
   end
 


### PR DESCRIPTION
チャット返信機能を実装しました。

●機能の説明
・チャットページ内の「返信」ボタンをクリックすると、チャット投稿のテキストエリアがフォーカスされ、テキストエリア内に「>> + 返信先の番号」が入力されます。
・「>> + 返信先の番号」に加えて投稿内容を入力して投稿すると、「>> + 返信先の番号」の部分がリンク化されており、クリックするとその番号のチャットの表示箇所までページ内ジャンプします。